### PR TITLE
bugfix/enhancement: Add abbr compatibility for transient prompts

### DIFF
--- a/conf.d/fish-you-could-use.fish
+++ b/conf.d/fish-you-could-use.fish
@@ -18,16 +18,26 @@ functions -q \
     _fycu_verify_ignored
 
 # Setup custom bindings needed to track abbr expansions
-for mode in default insert
-    bind -M $mode space _fycu_abbr_bind_space
-    bind -M $mode shift-enter _fycu_abbr_bind_newline
-
-    # If oh-my-posh is installed then add custom overlay that appends the
-    # fycu logic and then calls the original oh-my-posh function, otherwise,
-    # just add fycu function
-    if bind enter --user 2>/dev/null | string match -qe _omp_enter_key_handler
-        bind -M $mode enter _omp_enter_key_handler_fycu
-    else
+function _fycu_keybindings -d "Load default keybindings for FYCU"
+    for mode in default insert
+        bind -M $mode space _fycu_abbr_bind_space
+        bind -M $mode shift-enter _fycu_abbr_bind_newline
         bind -M $mode enter _fycu_abbr_bind_newline
     end
 end
+
+function _fycu_keybindings_omp -d "Load oh-my-posh compatiable enter key binding" --on-event fish_prompt
+    # If oh-my-posh is installed then add custom overlay that appends the
+    # fycu logic and then calls the original oh-my-posh function
+    for mode in default insert
+        if bind enter --user 2>/dev/null | string match -qe _omp_enter_key_handler
+            bind -M $mode enter _omp_enter_key_handler_fycu
+        end
+    end
+
+    # Delete the function after it's ran as it's no longer needed afterward
+    functions --erase _fycu_keybindings_omp
+end
+
+# Run the default keybindings
+_fycu_keybindings

--- a/conf.d/fish-you-could-use.fish
+++ b/conf.d/fish-you-could-use.fish
@@ -10,15 +10,8 @@ set --global FYCU_MESSAGE_POSITION before
 # Turned off by default due to bugs with detection
 set --global FYCU_ENABLE_ABBR false
 
-# Lock in event handlers for keybinds and initialization
-functions -q \
-    _fycu_abbr_bind_space \
-    _fycu_abbr_bind_newline \
-    _omp_enter_key_handler_fycu \
-    _fycu_verify_ignored
-
 # Setup custom bindings needed to track abbr expansions
-function _fycu_keybindings --on-variable fish_key_bindings
+function _fycu_keybindings
     for mode in default insert
         bind -M $mode space _fycu_abbr_bind_space
         bind -M $mode shift-enter _fycu_abbr_bind_newline
@@ -33,3 +26,11 @@ function _fycu_keybindings --on-variable fish_key_bindings
         end
     end
 end
+
+# Lock in event handlers for keybinds and initialization
+functions -q \
+    _fycu_abbr_bind_space \
+    _fycu_abbr_bind_newline \
+    _omp_enter_key_handler_fycu \
+    _fycu_verify_ignored \
+    _fycu_keybindings

--- a/conf.d/fish-you-could-use.fish
+++ b/conf.d/fish-you-could-use.fish
@@ -14,8 +14,9 @@ set --global FYCU_ENABLE_ABBR false
 functions -q \
     _fycu_abbr_bind_space \
     _fycu_abbr_bind_newline \
+    _fycu_verify_ignored \
     _omp_enter_key_handler_fycu \
-    _fycu_verify_ignored
+    _transient_execute_fycu
 
 # Setup custom bindings needed to track abbr expansions
 function _fycu_keybindings -d "Load default keybindings for FYCU"
@@ -26,17 +27,19 @@ function _fycu_keybindings -d "Load default keybindings for FYCU"
     end
 end
 
-function _fycu_keybindings_omp -d "Load oh-my-posh compatiable enter key binding" --on-event fish_prompt
-    # If oh-my-posh is installed then add custom overlay that appends the
-    # fycu logic and then calls the original oh-my-posh function
+function _fycu_keybindings_transient_prompts -d "Load oh-my-posh compatiable enter key binding" --on-event fish_prompt
     for mode in default insert
-        if bind enter --user 2>/dev/null | string match -qe _omp_enter_key_handler
+        # If any custom prompt is installed then add custom overlay that appends
+        # the fycu logic to the respective original function
+        if bind enter --user 2>/dev/null | string match -qe _omp_enter_key_handler # oh-my-posh
             bind -M $mode enter _omp_enter_key_handler_fycu
+        else if bind enter --user 2>/dev/null | string match -qe transient_execute # starship
+            bind -M $mode enter _transient_execute_fycu
         end
     end
 
     # Delete the function after it's ran as it's no longer needed afterward
-    functions --erase _fycu_keybindings_omp
+    functions --erase _fycu_keybindings_transient_prompts
 end
 
 # Run the default keybindings

--- a/conf.d/fish-you-could-use.fish
+++ b/conf.d/fish-you-could-use.fish
@@ -10,27 +10,24 @@ set --global FYCU_MESSAGE_POSITION before
 # Turned off by default due to bugs with detection
 set --global FYCU_ENABLE_ABBR false
 
-# Setup custom bindings needed to track abbr expansions
-function _fycu_keybindings
-    for mode in default insert
-        bind -M $mode space _fycu_abbr_bind_space
-        bind -M $mode shift-enter _fycu_abbr_bind_newline
-
-        # If oh-my-posh is installed then add custom overlay that appends the
-        # fycu logic and then calls the original oh-my-posh function, otherwise,
-        # just add fycu function
-        if bind enter --user 2>/dev/null | string match -qe _omp_enter_key_handler
-            bind -M $mode enter _omp_enter_key_handler_fycu
-        else
-            bind -M $mode enter _fycu_abbr_bind_newline
-        end
-    end
-end
-
 # Lock in event handlers for keybinds and initialization
 functions -q \
     _fycu_abbr_bind_space \
     _fycu_abbr_bind_newline \
     _omp_enter_key_handler_fycu \
-    _fycu_verify_ignored \
-    _fycu_keybindings
+    _fycu_verify_ignored
+
+# Setup custom bindings needed to track abbr expansions
+for mode in default insert
+    bind -M $mode space _fycu_abbr_bind_space
+    bind -M $mode shift-enter _fycu_abbr_bind_newline
+
+    # If oh-my-posh is installed then add custom overlay that appends the
+    # fycu logic and then calls the original oh-my-posh function, otherwise,
+    # just add fycu function
+    if bind enter --user 2>/dev/null | string match -qe _omp_enter_key_handler
+        bind -M $mode enter _omp_enter_key_handler_fycu
+    else
+        bind -M $mode enter _fycu_abbr_bind_newline
+    end
+end

--- a/functions/_transient_execute_fycu.fish
+++ b/functions/_transient_execute_fycu.fish
@@ -1,0 +1,16 @@
+function _transient_execute_fycu -d "Overlay fycu abbr check into starhsip's transient prompts"
+    # If we HAVEN'T ran one yet, now's the time we do so
+    if test $__fycu_abbr_used != 1
+        # If the command actually matches, then we shall expand it (let the
+        # system know we are!)
+        if abbr -q -- (string trim -- (commandline))
+            set -g __fycu_abbr_used 1
+        else
+            # And if not, then let the system know we're not
+            set -g __fycu_abbr_used 0
+        end
+    end
+
+    # Call the original function
+    transient_execute
+end


### PR DESCRIPTION
Fix abbreviation checking being broken due to prompts with the transient prompt feature (i.e. oh-my-posh and starship) overriding the enter key binding by appending the checking logic before the prompt's enter key function and then just calling that original function after the check. Also to make sure the bindings apply, bind them at the start of the prompt being first printed on screen (initialized) then erase itself so it's not called anymore afterward

Fixes #2 